### PR TITLE
Replace lodash for submodules

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,8 @@ Some files contain code from the [DP3T applications](https://github.com/DP-3T), 
 | [@react-navigation/native](https://www.npmjs.com/package/@react-navigation/native)                                | MIT          |
 | [@react-navigation/stack](https://www.npmjs.com/package/@react-navigation/stack)                                  | MIT          |
 | [i18n-js](https://www.npmjs.com/package/i18n-js)                                                                  | MIT          |
-| [lodash](https://www.npmjs.com/package/lodash)                                                                    | MIT          |
+| [lodash.pickby](https://www.npmjs.com/package/lodash.pickby)                                                      | MIT          |
+| [lodash.memoize](https://www.npmjs.com/package/lodash.memoize)                                                    | MIT          |
 | [mirror-creator](https://www.npmjs.com/package/mirror-creator)                                                    | MIT          |
 | [moment](https://www.npmjs.com/package/moment)                                                                    | MIT          |
 | [react](https://www.npmjs.com/package/react)                                                                      | MIT          |

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -458,7 +458,7 @@ SPEC CHECKSUMS:
   KituraContracts: e845e60dc8627ad0a76fa55ef20a45451d8f830b
   LoggerAPI: fb78461eedac5316b290f2404d88b9d614d96c57
   Logging: 7838d379d234d7e5ae1265fa02804a9084caf04c
-  Permission-Notifications: 231d0e1db2300b686548587d384ba414e6a93332
+  Permission-Notifications: 5ecb0f433b585c5621dc30b168772d60ae8574c2
   RCTRequired: cec6a34b3ac8a9915c37e7e4ad3aa74726ce4035
   RCTTypeSafety: 93006131180074cffa227a1075802c89a49dd4ce
   React: 29a8b1a02bd764fb7644ef04019270849b9a7ac3
@@ -469,10 +469,10 @@ SPEC CHECKSUMS:
   React-jsiexecutor: 1540d1c01bb493ae3124ed83351b1b6a155db7da
   React-jsinspector: 512e560d0e985d0e8c479a54a4e5c147a9c83493
   react-native-config: ae9ef3bdbf539f2d14ebaf4ebeba508f766e066a
-  react-native-netinfo: cd479ab1b67cdd1cb1403a99ecdb24190a6dd7ef
-  react-native-safe-area-context: ef6f16c66b0797ecae1bf86c103dfb3dc16fc33d
+  react-native-netinfo: eed0fb1d6a9424e98ce686f92aad62ff427d4bc9
+  react-native-safe-area-context: c39fc20a20cd66ebf1d56c6f8b8711142fbfee98
   react-native-splash-screen: 200d11d188e2e78cea3ad319964f6142b6384865
-  react-native-version-number: b415bbec6a13f2df62bf978e85bc0d699462f37f
+  react-native-version-number: 15563dc4145a94aabfc1faab2a9af10174a4204e
   React-RCTActionSheet: f41ea8a811aac770e0cc6e0ad6b270c644ea8b7c
   React-RCTAnimation: 49ab98b1c1ff4445148b72a3d61554138565bad0
   React-RCTBlob: a332773f0ebc413a0ce85942a55b064471587a71
@@ -483,12 +483,12 @@ SPEC CHECKSUMS:
   React-RCTText: fae545b10cfdb3d247c36c56f61a94cfd6dba41d
   React-RCTVibration: 4356114dbcba4ce66991096e51a66e61eda51256
   ReactCommon: ed4e11d27609d571e7eee8b65548efc191116eb3
-  RNCAsyncStorage: d059c3ee71738c39834a627476322a5a8cd5bf36
-  RNCCheckbox: 357578d3b42652c78ee9a1bb9bcfc3195af6e161
-  RNCMaskedView: 5a8ec07677aa885546a0d98da336457e2bea557f
+  RNCAsyncStorage: db711e29e5e0500d9bd21aa0c2e397efa45302b1
+  RNCCheckbox: 2e90172b1ba7a5c7d88f50f6243fe16566bf03aa
+  RNCMaskedView: f5c7d14d6847b7b44853f7acb6284c1da30a3459
   RNGestureHandler: 8f09cd560f8d533eb36da5a6c5a843af9f056b38
-  RNLocalize: b6df30cc25ae736d37874f9bce13351db2f56796
-  RNPermissions: ad71dd4f767ec254f2cd57592fbee02afee75467
+  RNLocalize: fc27ee5878ce5a3af73873fb2d8e866e0d1e6d84
+  RNPermissions: 1888705aebcc81714efa5dbff94351e4388ae012
   RNReanimated: b5ccb50650ba06f6e749c7c329a1bc3ae0c88b43
   RNScreens: c526239bbe0e957b988dacc8d75ac94ec9cb19da
   RNSVG: ce9d996113475209013317e48b05c21ee988d42e

--- a/package.json
+++ b/package.json
@@ -9,7 +9,15 @@
   "main": "index.js",
   "version": "0.2.3",
   "license": "EUPL-1.2",
-  "keywords": ["covid19", "react-native", "mobile", "dp3t", "portugal", "android", "ios"],
+  "keywords": [
+    "covid19",
+    "react-native",
+    "mobile",
+    "dp3t",
+    "portugal",
+    "android",
+    "ios"
+  ],
   "private": true,
   "repository": {
     "type": "git",
@@ -46,7 +54,8 @@
     "@react-navigation/native": "5.6.1",
     "@react-navigation/stack": "5.6.2",
     "i18n-js": "3.7.1",
-    "lodash": "4.17.15",
+    "lodash.memoize": "4.1.2",
+    "lodash.pickby": "4.6.0",
     "mirror-creator": "1.1.0",
     "moment": "2.27.0",
     "react": "16.11.0",

--- a/src/app/redux/permissions/selectors.js
+++ b/src/app/redux/permissions/selectors.js
@@ -9,7 +9,7 @@
  */
 
 import { createSelector } from 'reselect';
-import { pickBy } from 'lodash';
+import pickBy from 'lodash.pickby';
 
 import {
   BATTERY_PERMISSION,

--- a/src/app/services/i18n.js
+++ b/src/app/services/i18n.js
@@ -12,7 +12,7 @@
 import { I18nManager } from 'react-native';
 import i18n from 'i18n-js';
 import * as RNLocalize from 'react-native-localize';
-import { memoize } from 'lodash';
+import memoize from 'lodash.memoize';
 
 import Moment from 'moment';
 import 'moment/locale/pt';

--- a/yarn.lock
+++ b/yarn.lock
@@ -5561,6 +5561,16 @@ locate-path@^5.0.0:
   dependencies:
     p-locate "^4.1.0"
 
+lodash.memoize@4.1.2:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
+  integrity sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=
+
+lodash.pickby@4.6.0:
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/lodash.pickby/-/lodash.pickby-4.6.0.tgz#7dea21d8c18d7703a27c704c15d3b84a67e33aff"
+  integrity sha1-feoh2MGNdwOifHBMFdO4SmfjOv8=
+
 lodash.sortby@^4.7.0:
   version "4.7.0"
   resolved "https://registry.yarnpkg.com/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438"
@@ -5570,11 +5580,6 @@ lodash.throttle@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/lodash.throttle/-/lodash.throttle-4.1.1.tgz#c23e91b710242ac70c37f1e1cda9274cc39bf2f4"
   integrity sha1-wj6RtxAkKscMN/HhzaknTMOb8vQ=
-
-lodash@4.17.15:
-  version "4.17.15"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
-  integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
 
 lodash@^4.0.0, lodash@^4.17.10, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.4, lodash@^4.2.0, lodash@^4.3.0:
   version "4.17.19"


### PR DESCRIPTION
Currently, we have 259 low vulnerabilities of _Prototype Pollution_ all related to the `lodash` dependency.

This PR removes the `lodash` dependency and replace it with the two used submodules: `lodash.pickby` and `lodash.memoize`.