### PR TITLE
Add home long press

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,7 @@ Some files contain code from the [DP3T applications](https://github.com/DP-3T), 
 | [react-native-vector-icons](https://www.npmjs.com/package/react-native-vector-icons)                              | MIT          |
 | [react-native-version-number](https://www.npmjs.com/package/react-native-version-number)                          | MIT          |
 | [react-native-testing-library](https://github.com/callstack/react-native-testing-library)                         | MIT          |
+| [react-native-tooltips](https://github.com/prscX/react-native-tooltips)                                           | Apache 2.0   |
 | [react-navigation-redux-debouncer](https://www.npmjs.com/package/react-navigation-redux-debouncer)                | MIT          |
 | [react-redux](https://www.npmjs.com/package/react-redux)                                                          | MIT          |
 | [redux-actions](https://www.npmjs.com/package/redux-actions)                                                      | MIT          |

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -21,6 +21,7 @@ PODS:
   - glog (0.3.5)
   - Permission-Notifications (2.1.5):
     - RNPermissions
+  - pop (1.0.12)
   - RCTRequired (0.63.2)
   - RCTTypeSafety (0.63.2):
     - FBLazyVector (= 0.63.2)
@@ -277,8 +278,14 @@ PODS:
     - React
   - RNSVG (12.1.0):
     - React
+  - RNTooltips (1.0.2):
+    - pop (~> 1.0)
+    - React
+    - SexyTooltip
   - RNVectorIcons (6.6.0):
     - React
+  - SexyTooltip (1.2.7):
+    - pop (~> 1.0)
   - TrustKit (1.6.5)
   - Yoga (1.14.0)
 
@@ -325,6 +332,7 @@ DEPENDENCIES:
   - RNReanimated (from `../node_modules/react-native-reanimated`)
   - RNScreens (from `../node_modules/react-native-screens`)
   - RNSVG (from `../node_modules/react-native-svg`)
+  - RNTooltips (from `../node_modules/react-native-tooltips/ios`)
   - RNVectorIcons (from `../node_modules/react-native-vector-icons`)
   - TrustKit (~> 1.6)
   - Yoga (from `../node_modules/react-native/ReactCommon/yoga`)
@@ -332,6 +340,8 @@ DEPENDENCIES:
 SPEC REPOS:
   trunk:
     - boost-for-react-native
+    - pop
+    - SexyTooltip
     - TrustKit
 
 EXTERNAL SOURCES:
@@ -415,6 +425,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native-screens"
   RNSVG:
     :path: "../node_modules/react-native-svg"
+  RNTooltips:
+    :path: "../node_modules/react-native-tooltips/ios"
   RNVectorIcons:
     :path: "../node_modules/react-native-vector-icons"
   Yoga:
@@ -428,6 +440,7 @@ SPEC CHECKSUMS:
   Folly: b73c3869541e86821df3c387eb0af5f65addfab4
   glog: 40a13f7840415b9a77023fbcae0f1e6f43192af3
   Permission-Notifications: 231d0e1db2300b686548587d384ba414e6a93332
+  pop: d582054913807fd11fd50bfe6a539d91c7e1a55a
   RCTRequired: f13f25e7b12f925f1f6a6a8c69d929a03c0129fe
   RCTTypeSafety: 44982c5c8e43ff4141eb519a8ddc88059acd1f3a
   React: e1c65dd41cb9db13b99f24608e47dd595f28ca9a
@@ -462,7 +475,9 @@ SPEC CHECKSUMS:
   RNReanimated: b5ccb50650ba06f6e749c7c329a1bc3ae0c88b43
   RNScreens: c526239bbe0e957b988dacc8d75ac94ec9cb19da
   RNSVG: ce9d996113475209013317e48b05c21ee988d42e
+  RNTooltips: e13180e4339e2a85daabd09507f62a5a32d3dc8a
   RNVectorIcons: 0bb4def82230be1333ddaeee9fcba45f0b288ed4
+  SexyTooltip: e243da5a858c7160141cf35786a4033669d1efca
   TrustKit: 073855e3adecd317417bda4ac9e9ac54a2e3b9f2
   Yoga: 7740b94929bbacbddda59bf115b5317e9a161598
 

--- a/locales/en-GB.json
+++ b/locales/en-GB.json
@@ -582,6 +582,9 @@
     "placeholders": {
       "code": "xxx xxx xxx xxx"
     },
+    "popover": {
+      "home_long_press": "Press and hold to turn off/on tracing"
+    },
     "dialogs": {
       "network": {
         "title": "No Internet connection",

--- a/locales/en-GB.json
+++ b/locales/en-GB.json
@@ -583,7 +583,7 @@
       "code": "xxx xxx xxx xxx"
     },
     "popover": {
-      "home_long_press": "Press and hold to turn off/on tracing"
+      "home_long_press": "Press and hold to turn off/on monitoring"
     },
     "dialogs": {
       "network": {

--- a/locales/pt-PT.json
+++ b/locales/pt-PT.json
@@ -585,7 +585,7 @@
       "code": "xxx xxx xxx xxx"
     },
     "popover": {
-      "home_long_press": "Pressione continuamente para desligar/ligar o monitoramento"
+      "home_long_press": "Pressione continuamente para desligar/ligar o rastreio"
     },
     "dialogs": {
       "network": {

--- a/locales/pt-PT.json
+++ b/locales/pt-PT.json
@@ -584,6 +584,9 @@
     "placeholders": {
       "code": "xxx xxx xxx xxx"
     },
+    "popover": {
+      "home_long_press": "Pressione continuamente para desligar/ligar o monitoramento"
+    },
     "dialogs": {
       "network": {
         "title": "Sem ligação à internet",

--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     "react-native-svg": "12.1.0",
     "react-native-svg-icon": "0.8.1",
     "react-native-swiper": "1.6.0",
+    "react-native-tooltips": "1.0.2",
     "react-native-vector-icons": "6.6.0",
     "react-native-version-number": "0.3.6",
     "react-navigation-redux-debouncer": "0.0.2",

--- a/src/app/common/theme/colors.js
+++ b/src/app/common/theme/colors.js
@@ -13,6 +13,7 @@ export default {
   white: '#FFFFFF',
   black: '#191847',
 
+  grayLightest: "#EDEDED",
   grayLight: "#E5E5E5",
   gray: "#979797",
   grayDark: '#C4C4C4',

--- a/src/app/components/LoadingModal.js
+++ b/src/app/components/LoadingModal.js
@@ -78,7 +78,7 @@ export default function LoadingModal (props) {
       {({colors}) => (
         <Modal
           backdropColor={colors.blueDark}
-          backdropOpacity={0.9}
+          backdropOpacity={0.8}
           isVisible={visible}
           statusBarTranslucent
           onModalWillHide={modalHide}

--- a/src/app/services/tooltip.js
+++ b/src/app/services/tooltip.js
@@ -1,0 +1,80 @@
+/**
+ * Copyright (c) 2020 INESC TEC <https://www.inesctec.pt>
+ *
+ * This Source Code Form is subject to the terms of the European Union
+ * Public License, v. 1.2. If a copy of the EUPL was not distributed with
+ * this file, You can obtain one at https://opensource.org/licenses/EUPL-1.2.
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ */
+
+import { Platform } from 'react-native';
+import RNTooltips from 'react-native-tooltips';
+
+import { colors as commonColors, fontSizes } from '@app/common/theme';
+
+const POSITION = {
+  LEFT: 1,
+  RIGHT: 2,
+  TOP: 3,
+  BOTTOM: 4,
+};
+
+const DEFAULTS = {
+  position: POSITION.TOP,
+  tintColor: commonColors.grayLightest,
+  textColor: commonColors.blueLightest,
+  size: 'small',
+  autoHide: true,
+  clickToHide: true,
+  shadow: true,
+  arrow: true,
+  gravity: 2,
+  onHide: () => {},
+  duration: Platform.select({
+    ios: 4,
+    android: 4000,
+  }),
+  corner: Platform.select({
+    ios: 0,
+    android: 30,
+  }),
+};
+
+function getConfig(config) {
+  const props = {
+    ...DEFAULTS,
+    ...config,
+  };
+
+  props.size = fontSizes[props].size;
+
+  return props;
+}
+
+function show(
+  text = '',
+  target,
+  parent,
+  config = {},
+) {
+  const props = getConfig(config);
+
+  return RNTooltips.Show(
+    target,
+    parent,
+    {
+      text,
+      ...props,
+    },
+  );
+}
+
+function hide(target) {
+  return RNTooltips.Dismiss(target);
+}
+
+export default {
+  show,
+  hide,
+};

--- a/src/main/components/Recommendations/Template.js
+++ b/src/main/components/Recommendations/Template.js
@@ -9,7 +9,7 @@
  */
 
 import React from 'react';
-import { View, StyleSheet, Image } from 'react-native';
+import { View, StyleSheet } from 'react-native';
 import PropTypes from 'prop-types';
 
 import { ThemeConsumer } from '@app/contexts/Theme';

--- a/yarn.lock
+++ b/yarn.lock
@@ -7195,6 +7195,11 @@ react-native-testing-library@6.0.0:
   dependencies:
     pretty-format "^26.0.1"
 
+react-native-tooltips@1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/react-native-tooltips/-/react-native-tooltips-1.0.2.tgz#51f8f0e5e49f1a1999a37f257d7d04c0c5d69593"
+  integrity sha512-4JDI9fjWmCeiGzSGp5FFEPRYCX/kfawd+IU9LEIN8oICV5AWowF6xmCt0Qtxiqh8Ek4y0nF1JLSO3HeVXGXPAQ==
+
 react-native-vector-icons@6.6.0:
   version "6.6.0"
   resolved "https://registry.yarnpkg.com/react-native-vector-icons/-/react-native-vector-icons-6.6.0.tgz#66cf004918eb05d90778d64bd42077c1800d481b"


### PR DESCRIPTION
This PR adds the feature of quickly enable and disable monitoring while on Home Screen by simply long-press the home button.

It also adds a tooltip to help users notice this new feature.

<img width="250" src="https://user-images.githubusercontent.com/17494742/97464177-7bc05f80-1938-11eb-8e82-7d59da0e9db1.png">
