### PR TITLE
Fix typo in play-services-nearby download link

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ $ cp .env.example .env.production.debug
 $ yarn
 ```
 
-- If you're using **android**, you'll also need to manually download the binary distribution of [`play-services-nearby`](hhttps://github.com/google/exposure-notifications-android/raw/1803372dd30f151a477f031bd8a25bcf857db8c5/app/libs/play-services-nearby-exposurenotification-1.7.1-eap.aar) and attach it to your project on `android/app/libs`. You can do so by running on your project's root:
+- If you're using **android**, you'll also need to manually download the binary distribution of [`play-services-nearby`](https://github.com/google/exposure-notifications-android/raw/1803372dd30f151a477f031bd8a25bcf857db8c5/app/libs/play-services-nearby-exposurenotification-1.7.1-eap.aar) and attach it to your project on `android/app/libs`. You can do so by running on your project's root:
 ```sh
 $ wget https://github.com/google/exposure-notifications-android/raw/1803372dd30f151a477f031bd8a25bcf857db8c5/app/libs/play-services-nearby-exposurenotification-1.7.1-eap.aar -P android/app/libs
 ```

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ $ yarn
 
 - If you're using **android**, you'll also need to manually download the binary distribution of [`play-services-nearby`](hhttps://github.com/google/exposure-notifications-android/raw/1803372dd30f151a477f031bd8a25bcf857db8c5/app/libs/play-services-nearby-exposurenotification-1.7.1-eap.aar) and attach it to your project on `android/app/libs`. You can do so by running on your project's root:
 ```sh
-$ wget hhttps://github.com/google/exposure-notifications-android/raw/1803372dd30f151a477f031bd8a25bcf857db8c5/app/libs/play-services-nearby-exposurenotification-1.7.1-eap.aar -P android/app/libs
+$ wget https://github.com/google/exposure-notifications-android/raw/1803372dd30f151a477f031bd8a25bcf857db8c5/app/libs/play-services-nearby-exposurenotification-1.7.1-eap.aar -P android/app/libs
 ```
 
 ## Building


### PR DESCRIPTION
Change `hhttps` to `https` in `README.md`.